### PR TITLE
Added robvis to "Imports" field of DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     grid (>= 3.5.2), tidyr (>= 0.8.3), poibin (>= 1.3), stringr (>= 1.4.0), 
     MuMIn (>= 1.43.6), magrittr (>= 1.5), scales (>= 1.0.0), igraph (>= 1.2.2), graphics (>= 3.5.2),
     stats (>= 3.5.2), flexmix (>= 2.3.15), cluster (>= 2.0.7.1), factoextra (>= 1.0.5), fpc (>= 2.1.11.1),
-    cowplot (>= 0.9.4), mvtnorm (>= 1.0.8)
+    cowplot (>= 0.9.4), mvtnorm (>= 1.0.8), robvis (>= 0.3.0)
 Suggests: 
     testthat, knitr, rmarkdown, devtools
 VignetteBuilder: knitr


### PR DESCRIPTION
Hi @MathiasHarrer, 

Just adding `robvis` to the Imports field of `dmetar` so that it's installed when readers go to load it in the "Risk of Bias plots" Chapter. 

Sorry for the delay on all this - I'm hoping to start the related PR to the bookdown repo later today.

