### PR TITLE
fix variance distribution (levels 2 and 3 are currently reversed)

### DIFF
--- a/R/mlm.variance.distribution.R
+++ b/R/mlm.variance.distribution.R
@@ -72,8 +72,8 @@ mlm.variance.distribution = function(x){
 
   # Calculate variance proportions
   level1=((est.samp.var)/(m$sigma2[1]+m$sigma2[2]+est.samp.var)*100)
-  level2=((m$sigma2[2])/(m$sigma2[1]+m$sigma2[2]+est.samp.var)*100)
-  level3=((m$sigma2[1])/(m$sigma2[1]+m$sigma2[2]+est.samp.var)*100)
+  level2=((m$sigma2[1])/(m$sigma2[1]+m$sigma2[2]+est.samp.var)*100)
+  level3=((m$sigma2[2])/(m$sigma2[1]+m$sigma2[2]+est.samp.var)*100)
 
   # Prepare df for return
   Level=c("Level 1", "Level 2", "Level 3")


### PR DESCRIPTION
`m$sigma2[1]` corresponds to `sigma^2.1` variance component, so to level 2 factor, while `m$sigma2[2]` corresponds to `sigma^2.2` variance component, so to level 3 factor.